### PR TITLE
[refactor/chore]update namespaces to match new folder structure, CS8616경고 관련해서 _currentPage와 CloseAction부분 처리

### DIFF
--- a/batteryQI.sln
+++ b/batteryQI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "batteryQI", "batteryQI\batteryQI.csproj", "{12B1CC6B-40C2-4141-8516-D4A04C2D1363}"
 EndProject

--- a/batteryQI/ViewModels/MainWindowViewModel.cs
+++ b/batteryQI/ViewModels/MainWindowViewModel.cs
@@ -22,10 +22,12 @@ namespace batteryQI.ViewModels
             set => SetProperty(ref _currentPage, value);
         }
 
+        public Action? CloseAction { get; set; }
+
         public MainWindowViewModel()
         {
             // 초기 화면 설정
-            CurrentPage = new DashboardView();    
+            _currentPage = new DashboardView();
         }
         
         [RelayCommand]
@@ -45,8 +47,6 @@ namespace batteryQI.ViewModels
         {
             CurrentPage = new ManagerView();
         }
-
-        public Action CloseAction { get; set; }
 
         [RelayCommand]
         private void ExitButton()

--- a/batteryQI/ViewModels/MainWindowViewModel.cs
+++ b/batteryQI/ViewModels/MainWindowViewModel.cs
@@ -8,7 +8,7 @@ using System.Windows;
 using batteryQI.Models;
 using batteryQI.ViewModels.Bases;
 using CommunityToolkit.Mvvm.Input;
-using batteryQI.UserControls;
+using batteryQI.Views.UserControls;
 using batteryQI.Views;
 
 namespace batteryQI.ViewModels

--- a/batteryQI/Views/InspectionImage.xaml.cs
+++ b/batteryQI/Views/InspectionImage.xaml.cs
@@ -11,7 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using batteryQI.UserControls;
+using batteryQI.Views.UserControls;
 
 namespace batteryQI.Views
 {

--- a/batteryQI/Views/MainWindow.xaml.cs
+++ b/batteryQI/Views/MainWindow.xaml.cs
@@ -8,7 +8,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using batteryQI.UserControls;
+using batteryQI.Views.UserControls;
 using batteryQI.ViewModels;
 using Microsoft.Win32;
 

--- a/batteryQI/Views/UserControls/ChartView.xaml
+++ b/batteryQI/Views/UserControls/ChartView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="batteryQI.UserControls.ChartView"
+﻿<UserControl x:Class="batteryQI.Views.UserControls.ChartView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:scottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF">

--- a/batteryQI/Views/UserControls/ChartView.xaml.cs
+++ b/batteryQI/Views/UserControls/ChartView.xaml.cs
@@ -17,7 +17,7 @@ using ScottPlot.WPF;
 using ScottPlot;
 using ScottPlot.Plottables;
 
-namespace batteryQI.UserControls
+namespace batteryQI.Views.UserControls
 {
     /// <summary>
     /// Interaction logic for ChartPage.xaml

--- a/batteryQI/Views/UserControls/DashboardView.xaml
+++ b/batteryQI/Views/UserControls/DashboardView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="batteryQI.UserControls.DashboardView"
+﻿<UserControl x:Class="batteryQI.Views.UserControls.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid>

--- a/batteryQI/Views/UserControls/DashboardView.xaml.cs
+++ b/batteryQI/Views/UserControls/DashboardView.xaml.cs
@@ -15,7 +15,7 @@ using System.Windows.Shapes;
 using batteryQI.Views;
 using Microsoft.Win32;
 
-namespace batteryQI.UserControls
+namespace batteryQI.Views.UserControls
 {
     /// <summary>
     /// Interaction logic for DashboardView.xaml

--- a/batteryQI/Views/UserControls/ErrorInspection.xaml
+++ b/batteryQI/Views/UserControls/ErrorInspection.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="batteryQI.UserControls.ErrorInspection"
+﻿<UserControl x:Class="batteryQI.Views.UserControls.ErrorInspection"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid>

--- a/batteryQI/Views/UserControls/ErrorInspection.xaml.cs
+++ b/batteryQI/Views/UserControls/ErrorInspection.xaml.cs
@@ -13,7 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 
-namespace batteryQI.UserControls
+namespace batteryQI.Views.UserControls
 {
     /// <summary>
     /// Interaction logic for ErrorInspection.xaml

--- a/batteryQI/Views/UserControls/ErrorReason.xaml
+++ b/batteryQI/Views/UserControls/ErrorReason.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="batteryQI.UserControls.ErrorReason"
+﻿<UserControl x:Class="batteryQI.Views.UserControls.ErrorReason"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     

--- a/batteryQI/Views/UserControls/ErrorReason.xaml.cs
+++ b/batteryQI/Views/UserControls/ErrorReason.xaml.cs
@@ -14,7 +14,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using batteryQI.Views;
 
-namespace batteryQI.UserControls
+namespace batteryQI.Views.UserControls
 {
     /// <summary>
     /// Interaction logic for ErrorReason.xaml

--- a/batteryQI/Views/UserControls/ManagerView.xaml
+++ b/batteryQI/Views/UserControls/ManagerView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="batteryQI.UserControls.ManagerView"
+﻿<UserControl x:Class="batteryQI.Views.UserControls.ManagerView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 

--- a/batteryQI/Views/UserControls/ManagerView.xaml.cs
+++ b/batteryQI/Views/UserControls/ManagerView.xaml.cs
@@ -13,7 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 
-namespace batteryQI.UserControls
+namespace batteryQI.Views.UserControls
 {
     /// <summary>
     /// Interaction logic for ManagerPage.xaml


### PR DESCRIPTION
CS8616경고(초기화부분에 대해서 non-nullable인 변수가 null로 되어 있는 경우 표시되는 경고)
_currentPage의 경우는 프로퍼티를 사용해서 초기화를 해주지만 프로퍼티를 이용하여 초기화를 할경우 생성자가 끝나고 나서야 적용되어 경고가 뜬 것으로 보이며 _currentPage의 경우는 null을 가지면 안되는 경우이므로 직접 초기화를 해줘서 해결 (원래는 추가로 프로퍼티 부분에도 동일하게 값 넣어줌 ->프로퍼티가 단순 값지정으로만 쓰이기 때문에 굳이 동일하게 값 넣어서 프로퍼티 작동시켜주지 않음 그래서 제외) 그리고 CloseAction의 경우는 MainWindow가 초기화하는 중에 MainWindowViewModel이 초기화한 뒤에 CloseAction에 닫는 기능을 추가하기 때문에 그전에는 null로 존재하는 것을 의도했기 때문에 타입을 nullable로 수정, 그리고 확인하기 편하기 위해 메서드 위쪽 필드 선언하는 부분쪽으로 위치 변경