### PR TITLE
[refactor!]차트 그려지는 방식이 MVVM패턴에 맞게 수정

### DIFF
--- a/batteryQI/Extensions/PlotExtensions.cs
+++ b/batteryQI/Extensions/PlotExtensions.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using batteryQI.ViewModels;
+using ScottPlot.WPF;
+using System.Windows;
+using ScottPlot;
+using System.Diagnostics;
+
+namespace batteryQI.Extensions
+{
+    public static class PlotExtensions
+    {
+        public static readonly DependencyProperty PlotDataProperty =
+            DependencyProperty.RegisterAttached(
+                                                "PlotData",
+                                                typeof(object),
+                                                typeof(PlotExtensions),
+                                                new PropertyMetadata(null, OnPlotDataChanged)
+                                                );
+
+        public static void SetPlotData(DependencyObject element, object value)
+        {
+            element.SetValue(PlotDataProperty, value);
+        }
+
+        public static object GetPlotData(DependencyObject element)
+        {
+            return element.GetValue(PlotDataProperty);
+        }
+
+        private static void OnPlotDataChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is WpfPlot wpfPlot)
+            {
+                var data = e.NewValue;
+                wpfPlot.Plot.Clear();
+
+                if (data is Chart1ViewModel chart1Data)
+                {
+                    wpfPlot.Plot.Clear();
+                    wpfPlot.Plot.Add.Scatter(chart1Data.XData, chart1Data.YData);
+                    wpfPlot.Plot.Title("Chart 1");
+                    wpfPlot.Plot.XLabel("X-Axis");
+                    wpfPlot.Plot.YLabel("Y-Axis");
+                    //wpfPlot.Plot.Axes.AutoScaleX();
+                    //wpfPlot.Plot.Axes.SetLimitsY(-1.1, 1.1);
+                    //wpfPlot.Plot.Axes.SetLimits(0, 100, -1.1, 1.1);
+                }
+                else if (data is Chart2ViewModel chart2Data)
+                {
+                    wpfPlot.Plot.Clear();
+                    wpfPlot.Plot.Add.Pie(chart2Data.Values);
+                    wpfPlot.Plot.Title("Chart 2");
+                    //wpfPlot.Plot.Axes.AutoScale();
+                }
+                
+                //그래프 축범위 설정이 제대로 안되서 스케일 건드려볼려고 한것인데 잘 안되서 일단 남겨두고 다른 부분
+                wpfPlot.Plot.Axes.SetLimits(wpfPlot.Plot.Axes.GetDataLimits());
+                AxisLimits limits = wpfPlot.Plot.Axes.GetLimits();
+                Debug.WriteLine($"여기가 보고 싶은 값이다 휴먼 \r\n Axis Limits: Bottom={limits.Bottom}, Top={limits.Top}, Left={limits.Left}, Right={limits.Right}");
+
+                wpfPlot.Refresh();
+            }
+        }
+    }
+
+}

--- a/batteryQI/ViewModels/Bases/ViewModelBases.cs
+++ b/batteryQI/ViewModels/Bases/ViewModelBases.cs
@@ -12,14 +12,14 @@ using System.Windows.Controls;
 
 namespace batteryQI.ViewModels.Bases
 {
-    internal partial class ViewModelBases : ObservableObject
+    public partial class ViewModelBases : ObservableObject
     {
-        // 클릭 이벤트 등록
-        [RelayCommand]
-        private void LinkDB()
-        {
-            DBlink x = new();
-            x.Connect(); // 링크
-        }
+        //// 클릭 이벤트 등록
+        //[RelayCommand]
+        //private void LinkDB()
+        //{
+        //    DBlink x = new();
+        //    x.Connect(); // 링크
+        //}
     }
 }

--- a/batteryQI/ViewModels/ChartViewModel.cs
+++ b/batteryQI/ViewModels/ChartViewModel.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using batteryQI.ViewModels.Bases;
+
+namespace batteryQI.ViewModels
+{
+    public class ChartViewModel : ViewModelBases //이거 원래 internal이였음
+    {
+        private object _selectedTab;
+        public object SelectedTab
+        {
+            get => _selectedTab;
+            set => SetProperty(ref _selectedTab, value);
+        }
+
+        public ObservableCollection<TabItemViewModel> Tabs { get; } = new ObservableCollection<TabItemViewModel>();
+
+        public ChartViewModel()
+        {
+            Tabs.Add(new TabItemViewModel { Header = "불량률", Content = new Chart1ViewModel() });
+            Tabs.Add(new TabItemViewModel { Header = "불량유형", Content = new Chart2ViewModel() });
+        }
+    }
+    public class TabItemViewModel
+    {
+        public string Header { get; set; }
+        public object Content { get; set; }
+    }
+
+    public class Chart1ViewModel //chart1 그릴 데이터 관리
+    {
+        public double[] XData { get; } = Enumerable.Range(0, 100).Select(i => (double)i).ToArray();
+        public double[] YData { get; } = Enumerable.Range(0, 100).Select(i => Math.Sin(i * 0.1)).ToArray();
+    }
+
+    public class Chart2ViewModel //chart2 그릴 데이터 관리
+    {
+        public double[] Values { get; } = { 30, 20, 50 };
+        public string[] Labels { get; } = { "Type A", "Type B", "Type C" };
+    }
+}

--- a/batteryQI/Views/MainWindow.xaml.cs
+++ b/batteryQI/Views/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace batteryQI.Views
             InitializeComponent();
             var viewModel = new MainWindowViewModel();
             viewModel.CloseAction = () => this.Close();
-            DataContext = viewModel;
+            this.DataContext = viewModel;
         }
     }
 }

--- a/batteryQI/Views/UserControls/ChartView.xaml
+++ b/batteryQI/Views/UserControls/ChartView.xaml
@@ -1,20 +1,26 @@
 ﻿<UserControl x:Class="batteryQI.Views.UserControls.ChartView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:scottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF">
+             xmlns:scottPlot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+             xmlns:local="clr-namespace:batteryQI.Extensions"
+             xmlns:vm="clr-namespace:batteryQI.ViewModels">
 
     <Grid x:Name="MainGrid" Margin="0 70">
         <!-- TabControl with SelectionChanged event -->
-        <TabControl x:Name="ChartTabControl" SelectionChanged="ChartTabControl_SelectionChanged" Margin="10">
-            <!-- 첫 번째 차트 탭 -->
-            <TabItem Header="불량률" x:Name="Tab1">
-                <scottPlot:WpfPlot x:Name="Chart1Plot" />
-            </TabItem>
-
-            <!-- 두 번째 차트 탭 -->
-            <TabItem Header="불량유형" x:Name="Tab2">
-                <scottPlot:WpfPlot x:Name="Chart2Plot" />
-            </TabItem>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    SelectedItem="{Binding SelectedTab}"
+                    Margin="10">
+            <TabControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Header}"/>
+                </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <!--<ContentControl Content="{Binding Content}"/>-->
+                    <scottPlot:WpfPlot local:PlotExtensions.PlotData="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </Grid>
 </UserControl>

--- a/batteryQI/Views/UserControls/ChartView.xaml.cs
+++ b/batteryQI/Views/UserControls/ChartView.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Shapes;
 using ScottPlot.WPF;
 using ScottPlot;
 using ScottPlot.Plottables;
+using batteryQI.ViewModels;
 
 namespace batteryQI.Views.UserControls
 {
@@ -27,62 +28,7 @@ namespace batteryQI.Views.UserControls
         public ChartView()
         {
             InitializeComponent();
-        }
-
-      
-        private void ChartTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (e.Source is TabControl tabControl) 
-            {
-               
-                if (tabControl.SelectedItem == Tab1) 
-                {
-                    InitializeChart1();
-                }
-                else if (tabControl.SelectedItem == Tab2) 
-                {
-                    InitializeChart2();
-                }
-            }
-        }
-
-        private void InitializeChart1()
-        {
-            var plt = Chart1Plot.Plot; 
-            plt.Clear(); 
-
-            double[] xs1 = Enumerable.Range(0, 100).Select(i => (double)i).ToArray();
-            double[] ys1 = xs1.Select(x => Math.Sin(x * 0.1)).ToArray();
-
-            var scatter = plt.Add.Scatter(xs1, ys1);
-            scatter.LineWidth = 2;              
-            scatter.MarkerSize = 5;          
-
-            plt.Title("chart 1"); // 한글 안됨..
-            plt.XLabel("X-Axis");      
-            plt.YLabel("Y-Axis");      
-            plt.Legend.IsVisible = true;         
-            Chart1Plot.Refresh();                
-        }
-
-        private void InitializeChart2()
-        {
-            var plt = Chart2Plot.Plot;
-            plt.Clear();
-
-            double[] values = { 30, 20, 50 }; 
-            string[] labels = { "Type A", "Type B", "Type C" }; 
-
-            var pie = plt.Add.Pie(values);
-
-            for (int i = 0; i < values.Length; i++)
-            {
-                pie.Slices[i].Label = labels[i]; 
-            }
-
-            plt.Title("chart 2");
-            plt.Legend.IsVisible = true;
-            Chart2Plot.Refresh();
+            this.DataContext = new ChartViewModel();
         }
     }
 }


### PR DESCRIPTION
ScottPlot의 경우 MVVM에 맞게 하기엔 잘 되어 있지 않아서 그냥은 못하고 다른 간접적인 방법을 써야하는데 아직 완전히는 이해하지는 못했지만 첨부속성?이라는 것을 이용해서 하는 방식으로 구현 그래프 축 범위 설정해서 스케일 조절하는 부분이 문제가 약간 있어서 해결하려고 꽤 오랜 시간 투자했지만 해결책을 찾지 못해서(정확히는 몇몇 방법들을 찾기는 했지만 지금 사용하는 버전에는 불가능한 방법이거나 동작은 했는데 의도대로 제대로 되지 않아 해결되지 않았음) 일단 되는 것만 남겨두고 약간의 흔적을 남겨둔채로 다른 부분부터 하고 나서 뒤에 추가로 해결시도해볼 예정

+그리고 추가로 DataContext해서 연결하는 것을 명확히 표현하기 위해서 그냥 DataContext에서 this.DataContext로 수정