### PR TITLE
결과 페이지에서 다음 화면으로 넘어가는 기능 구현

### DIFF
--- a/batteryQI/Views/InspectionImage.xaml
+++ b/batteryQI/Views/InspectionImage.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="batteryQI.Views.InspectionImage"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:uc="clr-namespace:batteryQI.Views.UserControls"
         Height="850" Width="500">
     
     <Grid>
@@ -25,13 +26,11 @@
             <Image x:Name="AnalyzeImage" Source="{Binding battery.BatteryBitmapImage }" Stretch="Fill" Height="300"/>
         </Border>
 
-        <Grid Grid.Row="2" x:Name="inspectionSection">
-            <StackPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <Button Width="50" Margin="0 0 20 0" Content="정상" Command="{Binding NomalButton_ClickCommand}"/>
-                <Button Width="50" Margin="20 0 0 0" Content="불량" Command="{Binding ErrorButton_ClickCommand}"/>
-            </StackPanel>
+        <Grid Grid.Row="2">
+            <uc:ErrorInspection Visibility="{Binding ErrorInspectionVisibility}" />
+            <uc:ErrorReason Visibility="{Binding ErrorReasonVisibility}" />
         </Grid>
-        <Frame Grid.Row="2" x:Name="InspectionFrame" NavigationUIVisibility="Hidden"/>
+
 
     </Grid>
 </Window>

--- a/batteryQI/Views/UserControls/ErrorInspection.xaml
+++ b/batteryQI/Views/UserControls/ErrorInspection.xaml
@@ -1,10 +1,14 @@
 ﻿<UserControl x:Class="batteryQI.Views.UserControls.ErrorInspection"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Visibility="{Binding ErrorInspectionVisibility}">
+    
     <Grid>
         <StackPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <Button Width="50" Margin="0 0 20 0" Content="불량" Click="ErrorButton_Click"/>
-            <Button Width="50" Margin="20 0 0 0" Content="정상" Click="NomalButton_Click"/>
+            <Button Width="50" Margin="0 0 20 0" Content="불량" Command="{Binding ErrorButton_ClickCommand}"/>
+            <Button Width="50" Margin="20 0 0 0" Content="정상" Command="{Binding NomalButton_ClickCommand}"
+                    CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
+
         </StackPanel>
     </Grid>
 </UserControl>

--- a/batteryQI/Views/UserControls/ErrorInspection.xaml.cs
+++ b/batteryQI/Views/UserControls/ErrorInspection.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using batteryQI.ViewModels;
 
 namespace batteryQI.Views.UserControls
 {
@@ -23,16 +24,17 @@ namespace batteryQI.Views.UserControls
         public ErrorInspection()
         {
             InitializeComponent();
+            //this.DataContext = new InspectViewModel();
         }
 
-        private void NomalButton_Click(object sender, RoutedEventArgs e)
-        {
-            Window.GetWindow(this).Close();
-        }
+        //private void NomalButton_Click(object sender, RoutedEventArgs e)
+        //{
+        //    //Window.GetWindow(this).Close();
+        //}
 
-        private void ErrorButton_Click(object sender, RoutedEventArgs e)
-        {
-            
-        }
+        //private void ErrorButton_Click(object sender, RoutedEventArgs e)
+        //{
+
+        //}
     }
 }

--- a/batteryQI/Views/UserControls/ErrorReason.xaml
+++ b/batteryQI/Views/UserControls/ErrorReason.xaml
@@ -1,6 +1,7 @@
 ﻿<UserControl x:Class="batteryQI.Views.UserControls.ErrorReason"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Visibility="{Binding ErrorReasonVisibility}">
     
     <Grid>
         <Grid.RowDefinitions>
@@ -9,11 +10,13 @@
         </Grid.RowDefinitions>
         <ComboBox Grid.Row="0" x:Name="errorReasonCombo" Height="30" Width="150" SelectedIndex="0">
             <ComboBoxItem Content="불량 유형"/>
-            <ComboBoxItem Content="옵션 1"/>
-            <ComboBoxItem Content="옵션 2"/>
-            <ComboBoxItem Content="옵션 3"/>
+            <ComboBoxItem Content="Damage"/>
+            <ComboBoxItem Content="Pollution"/>
+            <ComboBoxItem Content="Damage and Pollution"/>
         </ComboBox>
 
-        <Button Grid.Row="1" Margin="30" Width="100" Content= "확인" Click="ErrorConfirmButton_Click"/>
+        <Button Grid.Row="1" Margin="30" Width="100" Content= "확인"
+                Command="{Binding ConfirmErrorReasonButton_ClickCommand}"
+                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
     </Grid>
 </UserControl>

--- a/batteryQI/Views/UserControls/ErrorReason.xaml.cs
+++ b/batteryQI/Views/UserControls/ErrorReason.xaml.cs
@@ -22,13 +22,13 @@ namespace batteryQI.Views.UserControls
     /// </summary>
     public partial class ErrorReason : UserControl
     {
-        // 선택된 데이터 전달 이벤트
-        public event Action<string> ErrorConfirmed;
+        //// 선택된 데이터 전달 이벤트
+        //public event Action<string> ErrorConfirmed;
 
         public ErrorReason()
         {
             InitializeComponent();
-            this.DataContext = new InspectViewModel();
+            //this.DataContext = new InspectViewModel();
         }
 
         //private void ErrorConfirmButton_Click(object sender, RoutedEventArgs e)
@@ -56,18 +56,18 @@ namespace batteryQI.Views.UserControls
         //    errorInfoView.ShowDialog();
         //}
 
-        private void ErrorConfirmButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (errorReasonCombo.SelectedIndex > 0)
-            {
-                // 선택된 콤보박스 값 전달
-                string selectedReason = (errorReasonCombo.SelectedItem as ComboBoxItem)?.Content.ToString();
-                ErrorConfirmed?.Invoke(selectedReason);
-            }
-            else
-            {
-                MessageBox.Show("불량 유형을 선택해 주세요.", "알림", MessageBoxButton.OK, MessageBoxImage.Warning);
-            }
-        }
+        //private void ErrorConfirmButton_Click(object sender, RoutedEventArgs e)
+        //{
+        //    if (errorReasonCombo.SelectedIndex > 0)
+        //    {
+        //        // 선택된 콤보박스 값 전달
+        //        string selectedReason = (errorReasonCombo.SelectedItem as ComboBoxItem)?.Content.ToString();
+        //        ErrorConfirmed?.Invoke(selectedReason);
+        //    }
+        //    else
+        //    {
+        //        MessageBox.Show("불량 유형을 선택해 주세요.", "알림", MessageBoxButton.OK, MessageBoxImage.Warning);
+        //    }
+        //}
     }
 }


### PR DESCRIPTION
결과 페이지에서 다음 화면으로 넘어가는 기능 구현
1) 첫 번째 화면에서 정상 버튼을 누르면 화면이 종료 구현
2) 첫 번째 화면에서 불량 버튼을 누르면 불량 유형을 선택하는 콤보 박스와 불량 확인 버튼이 나오도록 구현
3) 콤보박스에서 불량 유형을 선택하고, 불량 확인 버튼을 누르면 마지막 최종 확인 화면이 팝업되도록 구현

구현해야 할 기능
1) 첫 번째 화면에서 정상 버튼을 누른 후, DB에 Insert하는 기능
2) 배터리 검사 결과가 불량일 때 최종 확인 페이지에서 확인을 눌렀을 때 DB에 inesert하는 기능
3) 배터리 불량 유형 콤보박스에서 선택된 불량 유형을 배터리 구조체에 적용하는 기능